### PR TITLE
Fix logo cutoff on iPad portrait by capping SVG width to column size

### DIFF
--- a/src/components/CircleSquareLogoButton.svelte
+++ b/src/components/CircleSquareLogoButton.svelte
@@ -9,6 +9,12 @@
   a  > :global(svg) {
     width: clamp(60px, 18vw, 180px);
   }
+
+  @media screen and (max-width: 1000px) {
+    a > :global(svg) {
+      width: 80px;
+    }
+  }
   /* {
     font-family: Gelasio, serif;
     font-size: 1.25rem;


### PR DESCRIPTION
At max-width: 1000px the grid's first column is 80px, but the logo SVG
used clamp(60px, 18vw, 180px) which resolves to ~138px at 768px (iPad
portrait). The SVG overflowed the column and was clipped by the viewport's
left edge. Capping the SVG at 80px at this breakpoint keeps it within
its grid cell.

https://claude.ai/code/session_01U6RzPhWzTGE5n3otWnkmE1