### PR TITLE
Fix LinesLogoWrapper mobile overflow causing side scrolling

### DIFF
--- a/src/components/LinesLogoWrapper.svelte
+++ b/src/components/LinesLogoWrapper.svelte
@@ -34,6 +34,30 @@
     border: 0.75rem solid black;
     max-width: 1000px;
     padding: 2rem 4rem;
+    width: 100%;
+  }
+
+  @media (max-width: 600px) {
+    main {
+      padding: 1rem;
+      border-width: 0.4rem;
+    }
+
+    header {
+      flex-wrap: wrap;
+      justify-content: center;
+      gap: 0.5rem;
+    }
+
+    .primary-header-txt {
+      font-size: 1.3rem;
+      letter-spacing: 0.1rem;
+    }
+
+    .secondary-header-txt {
+      font-size: 0.85rem;
+      letter-spacing: 0.05rem;
+    }
   }
 
   main.doubleBorder {

--- a/src/components/LinesLogoWrapper.svelte
+++ b/src/components/LinesLogoWrapper.svelte
@@ -8,6 +8,7 @@
   header {
     display: flex;
     justify-content: space-between;
+    gap: 1rem;
     padding: 0.5rem;
     border-bottom: 4px solid black;
   }

--- a/src/components/logos/LineLogo.svelte
+++ b/src/components/logos/LineLogo.svelte
@@ -1,6 +1,7 @@
 <style>
   svg {
     width: 260px;
+    max-width: 100%;
   }
 </style>
 


### PR DESCRIPTION
Make the component responsive: SVG logo now shrinks with max-width: 100%,
main gets width: 100%, and a 600px breakpoint reduces padding, border,
and allows the header to wrap and center on small screens.

https://claude.ai/code/session_01JepzS2dGLpPRZet7sz7VJf