### PR TITLE
Fix Hawaiian Words page side scrolling on mobile

### DIFF
--- a/src/components/HeaderWithHawaiianPersonLogo.svelte
+++ b/src/components/HeaderWithHawaiianPersonLogo.svelte
@@ -38,6 +38,27 @@
     max-height: 150px;
     max-width: 120px;
   }
+
+  @media screen and (max-width: 600px) {
+    header {
+      flex-wrap: wrap;
+      justify-content: center;
+      gap: 0.5rem;
+    }
+
+    img {
+      max-height: 80px;
+      max-width: 70px;
+    }
+
+    header :global(.centered div:nth-child(1)) {
+      font-size: 1.2rem;
+    }
+
+    header :global(.centered div:nth-child(3)) {
+      margin: 0.25rem 0.5rem 0;
+    }
+  }
 </style>
 
 <header>


### PR DESCRIPTION
On narrow viewports the header's two SVG images (120px each) left too
little room for the text, and the 4rem horizontal margin on the subtitle
div pushed content past the viewport edge. Added a 600px media query
that shrinks the images, reduces the title font size, tightens the
subtitle margins, and lets the header wrap and center so nothing overflows.

https://claude.ai/code/session_018rj1LXSr6gGJZaMWBTw8ts