### PR TITLE
Fix mobile side scrolling on Longevity Coach page by constraining image width

### DIFF
--- a/src/routes/contents/diet-&-health/longevity-coach.md
+++ b/src/routes/contents/diet-&-health/longevity-coach.md
@@ -1,9 +1,17 @@
 <style>
 img {
-    max-width: 350px;
+    max-width: 100%;
     width: 350px;
     float: right;
     margin: 1.5rem 0 1.5rem 1.5rem;
+}
+
+@media screen and (max-width: 400px) {
+    img {
+        float: none;
+        width: 100%;
+        margin: 1.5rem 0;
+    }
 }
 
 blockquote > footer {


### PR DESCRIPTION
Added max-width: 100% to prevent the fixed 350px image from overflowing narrow
screens, and a media query to remove float on very small screens.

https://claude.ai/code/session_01S1X8gS9WDkRJEF5aSFh2pt