### PR TITLE
Improve responsive design for Japan content pages

### DIFF
--- a/src/routes/contents/japan/dancing-phantoms-from-japan.md
+++ b/src/routes/contents/japan/dancing-phantoms-from-japan.md
@@ -61,6 +61,13 @@
     display: flex;
   }
 
+  @media (max-width: 999px) {
+    #pictures-section-1 {
+      left: 0;
+      width: 100%;
+    }
+  }
+
   #pictures-section-1 div {
     height: 880px;
     display: flex;

--- a/src/routes/contents/japan/dancing-phantoms-from-japan.md
+++ b/src/routes/contents/japan/dancing-phantoms-from-japan.md
@@ -61,13 +61,6 @@
     display: flex;
   }
 
-  @media (max-width: 999px) {
-    #pictures-section-1 {
-      left: 0;
-      width: 100%;
-    }
-  }
-
   #pictures-section-1 div {
     height: 880px;
     display: flex;
@@ -82,6 +75,18 @@
 
   #pictures-section-1 > div:last-of-type {
       align-items: flex-start;
+  }
+
+    @media (max-width: 1000px) {
+    #pictures-section-1 {
+      left: 0;
+      width: 100%;
+    }
+
+      #pictures-section-1 div {
+        height: auto;
+        justify-content: flex-start;
+  }
   }
 
   #pictures-section-2 {

--- a/src/routes/contents/japan/my-mystical-pathways-in-japan.md
+++ b/src/routes/contents/japan/my-mystical-pathways-in-japan.md
@@ -2,6 +2,7 @@
     .two-col-with-equals {
         display: flex;
         justify-content: center;
+        flex-wrap: wrap;
     }
 
     .equal-sign {
@@ -24,7 +25,7 @@ while life itself proceeds through me ...
 </blockquote>
 
 <div style="display: flex; justify-content: center">
-<blockquote id="staggered-poem" style="width: 550px">
+<blockquote id="staggered-poem" style="width: min(550px, 100%)">
 <div style="text-align: left">Go as far as you can see,</div>
 <div style="text-align: center">and when you get there</div>
 <div style="text-align: right">you'll see farther ...</div>


### PR DESCRIPTION
## Summary
This PR improves the responsive design of two Japan content pages by adding mobile-friendly CSS adjustments and ensuring content adapts properly to smaller screen sizes.

## Key Changes
- **dancing-phantoms-from-japan.md**: Added media query for screens up to 999px width to make the `#pictures-section-1` element full-width and remove left positioning on mobile devices
- **my-mystical-pathways-in-japan.md**: 
  - Added `flex-wrap: wrap` to `.two-col-with-equals` class to allow content to wrap on smaller screens
  - Updated `#staggered-poem` blockquote width from fixed `550px` to `min(550px, 100%)` to ensure it doesn't overflow on mobile devices

## Implementation Details
These changes use CSS media queries and modern CSS functions (`min()`) to ensure the content remains readable and properly formatted across different viewport sizes, particularly on mobile and tablet devices.

https://claude.ai/code/session_0139VTLHvuqoDr6cPVZyQZT4