### PR TITLE
Add site search functionality with Vercel serverless backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,5 @@ yarn-error.log
 /cypress/screenshots/
 /dist/
 /.astro/
+/api/_search-index.json
 .vscode

--- a/README.md
+++ b/README.md
@@ -11,6 +11,16 @@ Built with [Astro](https://astro.build) and [Svelte 5](https://svelte.dev), migr
 - Almost everything is prerendered static HTML. Only two islands hydrate in the browser: the nav (`client:load` in the layout, for the accordion and mobile menu) and the Dancing Phantoms page (which repositions images with a `ResizeObserver`).
 - The ʻokina (U+02BB) is wrapped in `<span class="okina">` at build time by a rehype plugin in `svelte.config.js`, so CSS can give it a font with a correct advance width.
 
+## Search
+
+Site search is powered by a Vercel serverless function:
+
+- `scripts/build-search-index.mjs` runs at the start of `npm run build` and indexes every page in `src/content/` (title from frontmatter or the first heading, plus the page text with markup stripped) into `api/_search-index.json` (gitignored).
+- `api/search.js` is a Vercel serverless function served at `/api/search?q=words`. It ranks pages by term matches (title matches weighted highest, with a bonus for exact phrases) and returns the top results with a snippet around the first match.
+- The search box in the nav submits to `/search`, where `src/components/SearchResults.svelte` (a `client:only` island) calls the function and renders the results with matched terms highlighted.
+
+`astro dev` serves only the static site, not `/api`. To exercise search locally, run `npx vercel dev`, or test the function directly by importing its handler after generating the index with `npm run build:search-index`.
+
 ## Commands
 
 - `npm run dev` — dev server at http://localhost:4321
@@ -20,4 +30,4 @@ Built with [Astro](https://astro.build) and [Svelte 5](https://svelte.dev), migr
 
 ## Deployment
 
-`npm run build` produces a fully static site in `dist/` that can be deployed to any static host.
+`npm run build` produces a fully static site in `dist/` that can be deployed to any static host. On Vercel, the `api/` directory is additionally deployed as serverless functions, which the site search depends on.

--- a/api/search.js
+++ b/api/search.js
@@ -1,0 +1,102 @@
+import { readFileSync } from 'node:fs';
+
+// Vercel serverless function backing the site search. The index is generated
+// by scripts/build-search-index.mjs during `npm run build`; reading it with
+// `new URL(..., import.meta.url)` lets Vercel's file tracer bundle it with
+// the function.
+const PAGES = JSON.parse(
+  readFileSync(new URL('./_search-index.json', import.meta.url), 'utf8')
+);
+
+const MAX_RESULTS = 20;
+const SNIPPET_LENGTH = 220;
+
+export default function handler(req, res) {
+  const query = String(req.query.q ?? '').trim();
+  // The index only changes on deploys, so let Vercel's edge cache hold
+  // responses; a new deploy invalidates the cache.
+  res.setHeader('Cache-Control', 'public, max-age=0, s-maxage=86400');
+
+  if (!query) {
+    res.status(400).json({ error: 'Missing search query. Use /api/search?q=words' });
+    return;
+  }
+
+  const queryLower = query.toLowerCase();
+  const terms = [...new Set(queryLower.split(/\s+/).filter(Boolean))].slice(0, 10);
+
+  const scored = [];
+  for (const page of PAGES) {
+    const titleLower = page.title.toLowerCase();
+    const textLower = page.text.toLowerCase();
+
+    let score = 0;
+    let matchedTerms = 0;
+    for (const term of terms) {
+      const inTitle = countOccurrences(titleLower, term);
+      const inText = countOccurrences(textLower, term);
+      if (inTitle + inText > 0) matchedTerms += 1;
+      // Title hits dominate; body hits are capped so long pages don't
+      // drown out short, focused ones.
+      score += inTitle * 10 + Math.min(inText, 5);
+    }
+    if (matchedTerms === 0) continue;
+
+    if (matchedTerms === terms.length) score += 20;
+    if (terms.length > 1 && (titleLower.includes(queryLower) || textLower.includes(queryLower))) {
+      score += 20; // exact phrase bonus
+    }
+
+    scored.push({
+      score,
+      result: {
+        url: page.url,
+        title: page.title,
+        snippet: makeSnippet(page.text, textLower, terms),
+      },
+    });
+  }
+
+  scored.sort((a, b) => b.score - a.score);
+
+  res.status(200).json({
+    query,
+    terms,
+    total: scored.length,
+    results: scored.slice(0, MAX_RESULTS).map((entry) => entry.result),
+  });
+}
+
+// Terms match at word starts only, so "air" matches "airlines" but not
+// "fair" or "chairman".
+function termMatcher(term) {
+  return new RegExp('\\b' + term.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'g');
+}
+
+function countOccurrences(haystack, term) {
+  if (!term) return 0;
+  return (haystack.match(termMatcher(term)) ?? []).length;
+}
+
+// An excerpt of the page text centered on the first matched term.
+function makeSnippet(text, textLower, terms) {
+  let first = -1;
+  for (const term of terms) {
+    const index = textLower.search(termMatcher(term));
+    if (index !== -1 && (first === -1 || index < first)) first = index;
+  }
+  if (first === -1) return text.slice(0, SNIPPET_LENGTH);
+
+  let start = Math.max(0, first - Math.floor(SNIPPET_LENGTH / 3));
+  // Snap to a word boundary so snippets don't open mid-word.
+  if (start > 0) {
+    const nextSpace = text.indexOf(' ', start);
+    if (nextSpace !== -1 && nextSpace < first) start = nextSpace + 1;
+  }
+  const end = Math.min(text.length, start + SNIPPET_LENGTH);
+
+  let snippet = text.slice(start, end);
+  if (start > 0) snippet = '…' + snippet;
+  if (end < text.length) snippet += '…';
+  return snippet;
+}

--- a/api/search.js
+++ b/api/search.js
@@ -4,12 +4,41 @@ import { readFileSync } from 'node:fs';
 // by scripts/build-search-index.mjs during `npm run build`; reading it with
 // `new URL(..., import.meta.url)` lets Vercel's file tracer bundle it with
 // the function.
-const PAGES = JSON.parse(
+const RAW_PAGES = JSON.parse(
   readFileSync(new URL('./_search-index.json', import.meta.url), 'utf8')
 );
 
 const MAX_RESULTS = 20;
 const SNIPPET_LENGTH = 220;
+
+// Matching runs on "folded" text: lowercased, accents removed, and the
+// ʻokina and apostrophes dropped, so "Hawaii" finds "Hawaiʻi" and "obamas"
+// finds "Obama's". `starts` maps each folded character back to its position
+// in the original string, so snippets can show the original text.
+function fold(original) {
+  let folded = '';
+  const starts = [];
+  let index = 0;
+  for (const char of original) {
+    const foldedChar = char
+      .normalize('NFD')
+      .replace(/[\u0300-\u036f]/g, '') // combining accents (macrons etc.)
+      .replace(/[ʻ‘’']/g, '') // ʻokina and apostrophes
+      .toLowerCase();
+    for (const c of foldedChar) {
+      folded += c;
+      starts.push(index);
+    }
+    index += char.length;
+  }
+  return { folded, starts };
+}
+
+const PAGES = RAW_PAGES.map((page) => ({
+  ...page,
+  titleFolded: fold(page.title).folded,
+  textFold: fold(page.text),
+}));
 
 export default function handler(req, res) {
   const query = String(req.query.q ?? '').trim();
@@ -22,19 +51,16 @@ export default function handler(req, res) {
     return;
   }
 
-  const queryLower = query.toLowerCase();
-  const terms = [...new Set(queryLower.split(/\s+/).filter(Boolean))].slice(0, 10);
+  const foldedQuery = fold(query).folded.trim();
+  const terms = [...new Set(foldedQuery.split(/\s+/).filter(Boolean))].slice(0, 10);
 
   const scored = [];
   for (const page of PAGES) {
-    const titleLower = page.title.toLowerCase();
-    const textLower = page.text.toLowerCase();
-
     let score = 0;
     let matchedTerms = 0;
     for (const term of terms) {
-      const inTitle = countOccurrences(titleLower, term);
-      const inText = countOccurrences(textLower, term);
+      const inTitle = countOccurrences(page.titleFolded, term);
+      const inText = countOccurrences(page.textFold.folded, term);
       if (inTitle + inText > 0) matchedTerms += 1;
       // Title hits dominate; body hits are capped so long pages don't
       // drown out short, focused ones.
@@ -43,7 +69,10 @@ export default function handler(req, res) {
     if (matchedTerms === 0) continue;
 
     if (matchedTerms === terms.length) score += 20;
-    if (terms.length > 1 && (titleLower.includes(queryLower) || textLower.includes(queryLower))) {
+    if (
+      terms.length > 1 &&
+      (page.titleFolded.includes(foldedQuery) || page.textFold.folded.includes(foldedQuery))
+    ) {
       score += 20; // exact phrase bonus
     }
 
@@ -52,7 +81,7 @@ export default function handler(req, res) {
       result: {
         url: page.url,
         title: page.title,
-        snippet: makeSnippet(page.text, textLower, terms),
+        snippet: makeSnippet(page.text, page.textFold, terms, foldedQuery),
       },
     });
   }
@@ -61,7 +90,7 @@ export default function handler(req, res) {
 
   res.status(200).json({
     query,
-    terms,
+    terms, // folded, matching how the client should highlight
     total: scored.length,
     results: scored.slice(0, MAX_RESULTS).map((entry) => entry.result),
   });
@@ -78,14 +107,19 @@ function countOccurrences(haystack, term) {
   return (haystack.match(termMatcher(term)) ?? []).length;
 }
 
-// An excerpt of the page text centered on the first matched term.
-function makeSnippet(text, textLower, terms) {
-  let first = -1;
-  for (const term of terms) {
-    const index = textLower.search(termMatcher(term));
-    if (index !== -1 && (first === -1 || index < first)) first = index;
+// An excerpt of the page text centered on the exact phrase if the page
+// contains it, otherwise on the first matched term.
+function makeSnippet(text, textFold, terms, foldedQuery) {
+  let firstFolded =
+    terms.length > 1 ? textFold.folded.search(termMatcher(foldedQuery)) : -1;
+  if (firstFolded === -1) {
+    for (const term of terms) {
+      const index = textFold.folded.search(termMatcher(term));
+      if (index !== -1 && (firstFolded === -1 || index < firstFolded)) firstFolded = index;
+    }
   }
-  if (first === -1) return text.slice(0, SNIPPET_LENGTH);
+  if (firstFolded === -1) return text.slice(0, SNIPPET_LENGTH);
+  const first = textFold.starts[firstFolded];
 
   let start = Math.max(0, first - Math.floor(SNIPPET_LENGTH / 3));
   // Snap to a word boundary so snippets don't open mid-word.

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "type": "module",
   "scripts": {
     "dev": "astro dev",
-    "build": "astro build",
+    "build": "node scripts/build-search-index.mjs && astro build",
+    "build:search-index": "node scripts/build-search-index.mjs",
     "preview": "astro preview",
     "start": "astro preview",
     "cy:run": "cypress run",

--- a/scripts/build-search-index.mjs
+++ b/scripts/build-search-index.mjs
@@ -37,6 +37,22 @@ function routeForFile(file) {
   return '/' + rel;
 }
 
+// Named entities used in the content, so snippets show real characters.
+const NAMED_ENTITIES = {
+  nbsp: ' ', amp: '&', lt: '<', gt: '>', quot: '"', apos: "'",
+  ldquo: '“', rdquo: '”', lsquo: '‘', rsquo: '’',
+  hellip: '…', mdash: '—', ndash: '–',
+  Amacr: 'Ā', amacr: 'ā', Emacr: 'Ē', emacr: 'ē', Imacr: 'Ī', imacr: 'ī',
+  Omacr: 'Ō', omacr: 'ō', Umacr: 'Ū', umacr: 'ū',
+};
+
+function decodeEntities(text) {
+  return text
+    .replace(/&#x([0-9a-f]+);/gi, (_, hex) => String.fromCodePoint(parseInt(hex, 16)))
+    .replace(/&#(\d+);/g, (_, dec) => String.fromCodePoint(Number(dec)))
+    .replace(/&([a-zA-Z]+);/g, (_, name) => NAMED_ENTITIES[name] ?? ' ');
+}
+
 // Reduces an .svx or .svelte source to its title and readable text.
 function extractPage(source) {
   let title = null;
@@ -61,15 +77,16 @@ function extractPage(source) {
       title = heading[1].replace(/<[^>]+>/g, ' ').replace(/\s+/g, ' ').trim();
     }
   }
+  if (title) title = decodeEntities(title);
 
-  const text = source
+  const text = decodeEntities(source
     .replace(/\{[#/:@][^}]*\}/g, ' ') // svelte logic blocks
     .replace(/\{[^}]*\}/g, ' ') // svelte expressions
     .replace(/<[^>]+>/g, ' ') // html / component tags
     .replace(/!\[([^\]]*)\]\([^)]*\)/g, ' $1 ') // markdown images -> alt text
     .replace(/\[([^\]]*)\]\([^)]*\)/g, ' $1 ') // markdown links -> link text
     .replace(/^#{1,6}\s+/gm, '')
-    .replace(/[*_`~]+/g, '')
+    .replace(/[*_`~]+/g, ''))
     .replace(/\s+/g, ' ')
     .trim();
 

--- a/scripts/build-search-index.mjs
+++ b/scripts/build-search-index.mjs
@@ -53,8 +53,24 @@ function decodeEntities(text) {
     .replace(/&([a-zA-Z]+);/g, (_, name) => NAMED_ENTITIES[name] ?? ' ');
 }
 
-// Reduces an .svx or .svelte source to its title and readable text.
-function extractPage(source) {
+function componentImports(source, fromFile) {
+  return [...source.matchAll(/import\s+(\w+)\s+from\s+['"]([^'"]+\.svelte)['"]/g)]
+    .map((m) => ({
+      name: m[1],
+      file: path.resolve(path.dirname(fromFile), m[2]),
+    }));
+}
+
+// Reduces an .svx or .svelte file to its title and readable text. Text
+// rendered by an imported component belongs to the page too, so component
+// text is inlined — but only for components unique to a single page
+// (see uniquePageComponents below); components shared between pages are
+// layout boilerplate whose text would repeat across the whole index.
+function extractFile(file, { inlineComponents, inlineAll = false, visited = new Set() }) {
+  if (visited.has(file) || !fs.existsSync(file)) return { title: null, text: '' };
+  visited.add(file);
+
+  let source = fs.readFileSync(file, 'utf8');
   let title = null;
 
   const frontmatter = source.match(/^---\r?\n([\s\S]*?)\r?\n---/);
@@ -63,6 +79,8 @@ function extractPage(source) {
     if (titleLine) title = titleLine[1].trim().replace(/^['"]|['"]$/g, '');
     source = source.slice(frontmatter[0].length);
   }
+
+  const imports = componentImports(source, file);
 
   source = source
     .replace(/<script[\s\S]*?<\/script>/gi, ' ')
@@ -79,24 +97,47 @@ function extractPage(source) {
   }
   if (title) title = decodeEntities(title);
 
-  const text = decodeEntities(source
-    .replace(/\{[#/:@][^}]*\}/g, ' ') // svelte logic blocks
-    .replace(/\{[^}]*\}/g, ' ') // svelte expressions
-    .replace(/<[^>]+>/g, ' ') // html / component tags
-    .replace(/!\[([^\]]*)\]\([^)]*\)/g, ' $1 ') // markdown images -> alt text
-    .replace(/\[([^\]]*)\]\([^)]*\)/g, ' $1 ') // markdown links -> link text
-    .replace(/^#{1,6}\s+/gm, '')
-    .replace(/[*_`~]+/g, ''))
-    .replace(/\s+/g, ' ')
-    .trim();
+  let text = decodeEntities(
+    source
+      .replace(/\{[#/:@][^}]*\}/g, ' ') // svelte logic blocks
+      .replace(/\{[^}]*\}/g, ' ') // svelte expressions
+      .replace(/<[^>]+>/g, ' ') // html / component tags
+      .replace(/!\[([^\]]*)\]\([^)]*\)/g, ' $1 ') // markdown images -> alt text
+      .replace(/\[([^\]]*)\]\([^)]*\)/g, ' $1 ') // markdown links -> link text
+      .replace(/^#{1,6}\s+/gm, '')
+      .replace(/[*_`~]+/g, '')
+  );
 
-  return { title, text };
+  for (const imp of imports) {
+    if (!inlineAll && !inlineComponents.has(imp.file)) continue;
+    // Only imports actually rendered in the markup contribute text.
+    if (!new RegExp(`<${imp.name}(\\s|/|>)`).test(source)) continue;
+    // Everything nested inside an inlined component is part of it.
+    const child = extractFile(imp.file, { inlineComponents, inlineAll: true, visited });
+    if (child.text) text += ' ' + child.text;
+  }
+
+  return { title, text: text.replace(/\s+/g, ' ').trim() };
 }
 
+const contentFiles = collectContentFiles(CONTENT_ROOT);
+
+// Components imported by exactly one page hold that page's content;
+// components imported by several pages are shared layout chrome.
+const importCounts = new Map();
+for (const file of contentFiles) {
+  for (const imp of componentImports(fs.readFileSync(file, 'utf8'), file)) {
+    importCounts.set(imp.file, (importCounts.get(imp.file) ?? 0) + 1);
+  }
+}
+const uniquePageComponents = new Set(
+  [...importCounts].filter(([, count]) => count === 1).map(([file]) => file)
+);
+
 const pages = [];
-for (const file of collectContentFiles(CONTENT_ROOT)) {
+for (const file of contentFiles) {
   const url = routeForFile(file);
-  const { title, text } = extractPage(fs.readFileSync(file, 'utf8'));
+  const { title, text } = extractFile(file, { inlineComponents: uniquePageComponents });
   const fallbackName =
     url === '/' ? 'Home' : makeReadableName(url.split('/').at(-1));
   if (!text && !title) continue;

--- a/scripts/build-search-index.mjs
+++ b/scripts/build-search-index.mjs
@@ -1,0 +1,93 @@
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { makeReadableName } from '../src/helpers/makeReadableNameFromPath.js';
+
+// Builds the search index consumed by the Vercel serverless function in
+// api/search.js. Runs before `astro build` (see the build script in
+// package.json) so the index always matches the deployed pages. Every file
+// in src/content is a page, so indexing the content tree indexes the site.
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const CONTENT_ROOT = path.join(ROOT, 'src', 'content');
+// The leading underscore keeps Vercel from serving the index as a function.
+const OUT_FILE = path.join(ROOT, 'api', '_search-index.json');
+
+function collectContentFiles(dir) {
+  const files = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    if (entry.name.startsWith('.') || entry.name.startsWith('_')) continue;
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...collectContentFiles(full));
+    } else if (/\.(svx|svelte)$/.test(entry.name)) {
+      files.push(full);
+    }
+  }
+  return files;
+}
+
+function routeForFile(file) {
+  const rel = path
+    .relative(CONTENT_ROOT, file)
+    .replace(/\.(svx|svelte)$/, '')
+    .split(path.sep)
+    .join('/');
+  if (rel === 'index') return '/';
+  if (rel.endsWith('/index')) return '/' + rel.slice(0, -'/index'.length);
+  return '/' + rel;
+}
+
+// Reduces an .svx or .svelte source to its title and readable text.
+function extractPage(source) {
+  let title = null;
+
+  const frontmatter = source.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+  if (frontmatter) {
+    const titleLine = frontmatter[1].match(/^title:\s*(.+)$/m);
+    if (titleLine) title = titleLine[1].trim().replace(/^['"]|['"]$/g, '');
+    source = source.slice(frontmatter[0].length);
+  }
+
+  source = source
+    .replace(/<script[\s\S]*?<\/script>/gi, ' ')
+    .replace(/<style[\s\S]*?<\/style>/gi, ' ')
+    .replace(/<!--[\s\S]*?-->/g, ' ');
+
+  if (!title) {
+    const heading =
+      source.match(/<h[12][^>]*>([\s\S]*?)<\/h[12]>/i) ||
+      source.match(/^#{1,2}\s+(.+)$/m);
+    if (heading) {
+      title = heading[1].replace(/<[^>]+>/g, ' ').replace(/\s+/g, ' ').trim();
+    }
+  }
+
+  const text = source
+    .replace(/\{[#/:@][^}]*\}/g, ' ') // svelte logic blocks
+    .replace(/\{[^}]*\}/g, ' ') // svelte expressions
+    .replace(/<[^>]+>/g, ' ') // html / component tags
+    .replace(/!\[([^\]]*)\]\([^)]*\)/g, ' $1 ') // markdown images -> alt text
+    .replace(/\[([^\]]*)\]\([^)]*\)/g, ' $1 ') // markdown links -> link text
+    .replace(/^#{1,6}\s+/gm, '')
+    .replace(/[*_`~]+/g, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+
+  return { title, text };
+}
+
+const pages = [];
+for (const file of collectContentFiles(CONTENT_ROOT)) {
+  const url = routeForFile(file);
+  const { title, text } = extractPage(fs.readFileSync(file, 'utf8'));
+  const fallbackName =
+    url === '/' ? 'Home' : makeReadableName(url.split('/').at(-1));
+  if (!text && !title) continue;
+  pages.push({ url, title: title || fallbackName, text });
+}
+
+pages.sort((a, b) => a.url.localeCompare(b.url));
+
+fs.mkdirSync(path.dirname(OUT_FILE), { recursive: true });
+fs.writeFileSync(OUT_FILE, JSON.stringify(pages));
+console.log(`Search index: ${pages.length} pages -> ${path.relative(ROOT, OUT_FILE)}`);

--- a/src/components/Nav.svelte
+++ b/src/components/Nav.svelte
@@ -162,8 +162,8 @@
       <input
         type="search"
         name="q"
-        placeholder="Search all pages"
-        aria-label="Search all pages"
+        placeholder="Search"
+        aria-label="Search"
         required />
     </form>
 

--- a/src/components/Nav.svelte
+++ b/src/components/Nav.svelte
@@ -84,6 +84,18 @@
     text-decoration: underline;
   }
 
+  form.search {
+    margin-bottom: 1rem;
+  }
+
+  form.search input {
+    width: 100%;
+    box-sizing: border-box;
+    font: inherit;
+    padding: 0.4rem 0.6rem;
+    border: 1px solid var(--second-darkest-hue);
+  }
+
   nav > div {
     color: white;
     margin-bottom: 1rem;
@@ -146,6 +158,15 @@
   </label>
 
   <nav>
+    <form class="search" role="search" action="/search" method="get">
+      <input
+        type="search"
+        name="q"
+        placeholder="Search all pages"
+        aria-label="Search all pages"
+        required />
+    </form>
+
     {#each processedLinks as link}
       {#if link.name === 'About Uncle Jack'}
         <div class={link.path}>

--- a/src/components/SearchResults.svelte
+++ b/src/components/SearchResults.svelte
@@ -38,17 +38,61 @@
     search(q);
   }
 
+  // Same folding as the API: lowercase, accents removed, ʻokina and
+  // apostrophes dropped, with a map from folded positions back to the
+  // original string so matches can be located in the displayed snippet.
+  function fold(original) {
+    let folded = '';
+    const starts = [];
+    const ends = [];
+    let index = 0;
+    for (const char of original) {
+      const foldedChar = char
+        .normalize('NFD')
+        .replace(/[\u0300-\u036f]/g, '')
+        .replace(/[ʻ‘’']/g, '')
+        .toLowerCase();
+      for (const c of foldedChar) {
+        folded += c;
+        starts.push(index);
+        ends.push(index + char.length);
+      }
+      index += char.length;
+    }
+    return { folded, starts, ends };
+  }
+
   // Splits a snippet into plain and matched parts so matches can be
-  // rendered inside <mark> without touching innerHTML.
+  // rendered inside <mark> without touching innerHTML. The API returns
+  // folded terms, so matching runs on the folded snippet and the ranges
+  // are mapped back to the original text.
   function highlight(snippet, terms) {
     if (!terms.length) return [{ text: snippet, hit: false }];
-    const escaped = terms.map((t) => t.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'));
-    // Word-start matches only, mirroring how the API counts matches.
-    const matcher = new RegExp(`\\b(${escaped.join('|')})`, 'gi');
-    return snippet
-      .split(matcher)
-      .filter((part) => part !== '')
-      .map((part) => ({ text: part, hit: terms.includes(part.toLowerCase()) }));
+    const { folded, starts, ends } = fold(snippet);
+
+    const ranges = [];
+    for (const term of terms) {
+      const escaped = term.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+      const matcher = new RegExp(`\\b${escaped}`, 'g'); // word-start, like the API
+      let match;
+      while ((match = matcher.exec(folded)) !== null) {
+        if (match[0].length === 0) break;
+        ranges.push([starts[match.index], ends[match.index + match[0].length - 1]]);
+      }
+    }
+    ranges.sort((a, b) => a[0] - b[0]);
+
+    const parts = [];
+    let position = 0;
+    for (const [start, end] of ranges) {
+      if (end <= position) continue; // overlaps a previous match
+      const from = Math.max(start, position);
+      if (from > position) parts.push({ text: snippet.slice(position, from), hit: false });
+      parts.push({ text: snippet.slice(from, end), hit: true });
+      position = end;
+    }
+    if (position < snippet.length) parts.push({ text: snippet.slice(position), hit: false });
+    return parts;
   }
 
   if (query.trim()) search(query.trim());

--- a/src/components/SearchResults.svelte
+++ b/src/components/SearchResults.svelte
@@ -103,7 +103,9 @@
   section {
     width: 100%;
     max-width: 42rem;
+    margin: 0 auto;
     padding: 0 1rem 2rem;
+    box-sizing: border-box;
   }
 
   form {

--- a/src/components/SearchResults.svelte
+++ b/src/components/SearchResults.svelte
@@ -1,0 +1,154 @@
+<script>
+  // Rendered with client:only, so this only ever runs in the browser and can
+  // read location.search directly. Results come from the Vercel serverless
+  // function at /api/search.
+  let query = $state(new URLSearchParams(location.search).get('q') ?? '');
+  let searchedQuery = $state('');
+  let searchedTerms = $state([]);
+  let results = $state([]);
+  let total = $state(0);
+  let loading = $state(false);
+  let error = $state('');
+
+  async function search(q) {
+    loading = true;
+    error = '';
+    try {
+      const response = await fetch(`/api/search?q=${encodeURIComponent(q)}`);
+      if (!response.ok) throw new Error(`Search failed (${response.status})`);
+      const data = await response.json();
+      results = data.results;
+      total = data.total;
+      searchedTerms = data.terms;
+      searchedQuery = q;
+    } catch (e) {
+      error = e.message || 'Search failed';
+    } finally {
+      loading = false;
+    }
+  }
+
+  function submit(event) {
+    event.preventDefault();
+    const q = query.trim();
+    if (!q || q === searchedQuery) return;
+    const url = new URL(location.href);
+    url.searchParams.set('q', q);
+    history.replaceState(null, '', url);
+    search(q);
+  }
+
+  // Splits a snippet into plain and matched parts so matches can be
+  // rendered inside <mark> without touching innerHTML.
+  function highlight(snippet, terms) {
+    if (!terms.length) return [{ text: snippet, hit: false }];
+    const escaped = terms.map((t) => t.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'));
+    // Word-start matches only, mirroring how the API counts matches.
+    const matcher = new RegExp(`\\b(${escaped.join('|')})`, 'gi');
+    return snippet
+      .split(matcher)
+      .filter((part) => part !== '')
+      .map((part) => ({ text: part, hit: terms.includes(part.toLowerCase()) }));
+  }
+
+  if (query.trim()) search(query.trim());
+</script>
+
+<section aria-label="Site search">
+  <h2>Search</h2>
+
+  <form role="search" onsubmit={submit}>
+    <input
+      type="search"
+      name="q"
+      placeholder="Search all pages"
+      aria-label="Search all pages"
+      bind:value={query}
+    />
+    <button type="submit">Search</button>
+  </form>
+
+  {#if loading}
+    <p class="status">Searching…</p>
+  {:else if error}
+    <p class="status">Something went wrong: {error}. Please try again.</p>
+  {:else if searchedQuery}
+    {#if results.length === 0}
+      <p class="status">No pages found for “{searchedQuery}”.</p>
+    {:else}
+      <p class="status">
+        {total} {total === 1 ? 'page' : 'pages'} found for “{searchedQuery}”{total > results.length ? `, showing the top ${results.length}` : ''}.
+      </p>
+      <ol>
+        {#each results as result (result.url)}
+          <li>
+            <a href={result.url}>{result.title}</a>
+            {#if result.snippet}
+              <p class="snippet">
+                {#each highlight(result.snippet, searchedTerms) as part}
+                  {#if part.hit}<mark>{part.text}</mark>{:else}{part.text}{/if}
+                {/each}
+              </p>
+            {/if}
+          </li>
+        {/each}
+      </ol>
+    {/if}
+  {:else}
+    <p class="status">Type a word or phrase to search every page of the site.</p>
+  {/if}
+</section>
+
+<style>
+  section {
+    width: 100%;
+    max-width: 42rem;
+    padding: 0 1rem 2rem;
+  }
+
+  form {
+    display: flex;
+    gap: 0.5rem;
+    margin-bottom: 1.5rem;
+  }
+
+  input {
+    flex: 1;
+    min-width: 0;
+    font: inherit;
+    padding: 0.4rem 0.6rem;
+  }
+
+  button {
+    font: inherit;
+    padding: 0.4rem 1rem;
+    color: white;
+    background-color: var(--second-darkest-hue, #333);
+    border: none;
+    cursor: pointer;
+  }
+
+  .status {
+    font-style: italic;
+  }
+
+  ol {
+    padding-left: 1.25rem;
+  }
+
+  li {
+    margin-bottom: 1.25rem;
+  }
+
+  li > a {
+    font-size: 1.15rem;
+  }
+
+  .snippet {
+    margin: 0.25rem 0 0;
+  }
+
+  mark {
+    background-color: #ffe89a;
+  }
+</style>

--- a/src/content/contents/travel/private-outings.svx
+++ b/src/content/contents/travel/private-outings.svx
@@ -25,7 +25,7 @@ MOST OF MY OUTINGS are pleasant strolls through beautiful and interesting areas 
 We visit every major historic place in The Capitol District and Civic Center. Even long-time residents of Honolulu are amazed at how much they discover on this one mile walk.
 
 ##### TOUR #2: UNIVERSITY OF HAWAIʻI & EAST-WEST CENTER
-We ramble around selected highlights of these twin institutions located in the lower Mdnoa Valley. I’ve been attending classes at the University since the mid-1950s, longer than any student or faculty member on campus, and I still audit one course every semester. This tour includes only my favorite spots at both facilities, but it takes much longer than the official tours conducted by either the University or the East-West Center.
+We ramble around selected highlights of these twin institutions located in the lower M&#257;noa Valley. I’ve been attending classes at the University since the mid-1950s, longer than any student or faculty member on campus, and I still audit one course every semester. This tour includes only my favorite spots at both facilities, but it takes much longer than the official tours conducted by either the University or the East-West Center.
 
 ##### TOUR #3: PRESIDENT OBAMA’S NEIGHBORHOOD
 Lasting over two hours, this highly informative walking tour is a chronological narration about the unusual life of the most famous person born in the Hawaiian Islands, with special emphasis on the decade of the 1970s. 

--- a/src/pages/search.astro
+++ b/src/pages/search.astro
@@ -1,0 +1,10 @@
+---
+import BaseLayout from '../layouts/BaseLayout.astro';
+import SearchResults from '../components/SearchResults.svelte';
+---
+
+<!-- client:only because the component reads location.search and calls the
+     /api/search serverless function; there is nothing useful to prerender. -->
+<BaseLayout title="Search — Jack Shields Christensen">
+  <SearchResults client:only="svelte" />
+</BaseLayout>


### PR DESCRIPTION
## Summary
This PR adds a complete site search feature powered by a Vercel serverless function, allowing users to search across all pages with ranked results and highlighted matches.

## Key Changes

- **Search Index Generation** (`scripts/build-search-index.mjs`): New build script that runs before `astro build` to extract and index page titles and text from all content files into `api/_search-index.json`. Strips markup, extracts titles from frontmatter or headings, and normalizes text for searching.

- **Serverless Search API** (`api/search.js`): Vercel function at `/api/search?q=words` that:
  - Ranks pages by term matches with title matches weighted 10x higher than body matches
  - Caps body match scoring to prevent long pages from dominating results
  - Applies bonuses for matching all query terms (+20) and exact phrase matches (+20)
  - Returns top 20 results with snippets centered on first match
  - Sets cache headers to leverage Vercel's edge cache across deploys

- **Search Results Component** (`src/components/SearchResults.svelte`): Client-only island that:
  - Reads query from URL search params and calls the API
  - Displays loading, error, and result states
  - Highlights matched terms in snippets using `<mark>` tags
  - Provides a search form with URL state management via `history.replaceState`

- **Search Page** (`src/pages/search.astro`): New `/search` route that renders the SearchResults component with `client:only` hydration.

- **Navigation Integration** (`src/components/Nav.svelte`): Added search form in the navigation sidebar that submits to `/search`.

- **Build Configuration** (`package.json`): Updated build script to generate search index before Astro build; added separate `build:search-index` script.

## Notable Implementation Details

- Search matches are word-start only (e.g., "air" matches "airlines" but not "fair"), mirroring the API's match counting
- Snippets intelligently snap to word boundaries to avoid mid-word truncation
- The search index is gitignored and generated fresh on each build, ensuring it always matches deployed pages
- Component uses Svelte 5 runes (`$state`) for reactive state management
- Proper accessibility with `role="search"` and semantic HTML

https://claude.ai/code/session_011ptspfaKrAJixofJXEuq2T