### PR TITLE
Handle pages named after their own folder

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -87,6 +87,14 @@ function wrapOkina() {
 // are MDX; Svelte remains only for the hydrated islands (Nav, SearchResults).
 export default defineConfig({
   output: 'static',
+  // Pages named after their own folder used to be served with the segment
+  // repeated; keep the old URLs working.
+  redirects: {
+    '/about-uncle-jack/about-uncle-jack': '/about-uncle-jack',
+    '/contents/clean-air-team/clean-air-team': '/contents/clean-air-team',
+    '/featured/mahatma-gandhi/mahatma-gandhi': '/featured/mahatma-gandhi',
+    '/featured/the-mature-american/the-mature-american': '/featured/the-mature-american',
+  },
   // The unified (remark/rehype) processor instead of Astro's default one:
   // custom plugins only run through `markdown.processor`, and the MDX
   // integration inherits this pipeline. `dashes: true` matches mdsvex's

--- a/scripts/build-search-index.mjs
+++ b/scripts/build-search-index.mjs
@@ -34,6 +34,12 @@ function routeForFile(file) {
     .join('/');
   if (rel === 'index') return '/';
   if (rel.endsWith('/index')) return '/' + rel.slice(0, -'/index'.length);
+  // A page named after its own folder is served at the folder's URL
+  // (see src/pages/[...slug].astro).
+  const segments = rel.split('/');
+  if (segments.length > 1 && segments.at(-1) === segments.at(-2)) {
+    return '/' + segments.slice(0, -1).join('/');
+  }
   return '/' + rel;
 }
 

--- a/src/helpers/navLinks.js
+++ b/src/helpers/navLinks.js
@@ -29,8 +29,14 @@ export function getAllLinks(dir = CONTENT_ROOT) {
     if (entry.isFile() && !entry.name.endsWith('.mdx')) continue;
 
     const childFileName = removeFileEnding(entry.name);
+    // A page named after its own folder is served at the folder's URL
+    // (see src/pages/[...slug].astro), so its link drops the repeated segment.
+    const isFolderNamesake =
+      entry.isFile() &&
+      dir !== CONTENT_ROOT &&
+      childFileName === path.basename(dir);
     const routePath = path
-      .relative(CONTENT_ROOT, path.join(dir, childFileName))
+      .relative(CONTENT_ROOT, isFolderNamesake ? dir : path.join(dir, childFileName))
       .split(path.sep)
       .join('/');
 

--- a/src/pages/[...slug].astro
+++ b/src/pages/[...slug].astro
@@ -22,7 +22,15 @@ export async function getStaticPaths() {
 
     const isFolderIndex = route.endsWith('/index');
     const folderRoute = isFolderIndex ? route.slice(0, -'/index'.length) : null;
-    const slug = isFolderIndex ? folderRoute : route;
+    let slug = isFolderIndex ? folderRoute : route;
+
+    // A page named after its own folder (about-uncle-jack/about-uncle-jack)
+    // is that folder's page, served at the folder's URL rather than with the
+    // segment repeated.
+    const segments = route.split('/');
+    if (!isFolderIndex && segments.length > 1 && segments.at(-1) === segments.at(-2)) {
+      slug = segments.slice(0, -1).join('/');
+    }
 
     // The <title> and meta description come from the page's YAML frontmatter
     // (MDX exports it as `frontmatter`). A page without one still gets a


### PR DESCRIPTION
## Summary
This PR updates the routing logic to handle pages that are named after their own folder (e.g., `about-uncle-jack/about-uncle-jack.mdx`). These pages are now served at the folder's URL (`/about-uncle-jack`) rather than with the segment repeated (`/about-uncle-jack/about-uncle-jack`).

## Key Changes
- **src/pages/[...slug].astro**: Added logic to detect when a page filename matches its parent folder name and normalize the slug to the folder path
- **astro.config.mjs**: Added redirect rules to maintain backward compatibility with old URLs that had the repeated segment
- **src/helpers/navLinks.js**: Updated navigation link generation to use the folder URL for pages named after their folder
- **scripts/build-search-index.mjs**: Updated search index route generation to use the folder URL for these pages

## Implementation Details
The solution detects folder-namesake pages by comparing the last two segments of the route path. When they match, the slug is trimmed to remove the repeated segment. This ensures consistent URL structure across:
- Static page generation
- Navigation link generation
- Search index routing
- Backward compatibility via redirects

Four existing pages are affected by this change and have redirect rules configured to preserve old URLs.

https://claude.ai/code/session_01JuKLiQ8U8pGqZYNamTMu9X