### PR TITLE
Allow multiple menu sections to be open at the same time

### DIFF
--- a/src/components/Nav.svelte
+++ b/src/components/Nav.svelte
@@ -3,18 +3,26 @@
 
   let { links, currentPath = "/" } = $props();
 
-  // Sections start closed on a fresh visit, but a section the visitor opened
-  // stays open across page navigations (which are full page loads now).
-  const STORAGE_KEY = "nav-opened-section";
+  // Sections start closed on a fresh visit, but sections the visitor opened
+  // stay open across page navigations (which are full page loads now).
+  const STORAGE_KEY = "nav-opened-sections";
+
+  function loadOpenedSectionPaths() {
+    if (typeof sessionStorage === "undefined") return [];
+    try {
+      const stored = JSON.parse(sessionStorage.getItem(STORAGE_KEY) ?? "[]");
+      return Array.isArray(stored) ? stored : [];
+    } catch {
+      return [];
+    }
+  }
+
   const nav = $state({
-    openedSectionPath:
-      typeof sessionStorage !== "undefined"
-        ? (sessionStorage.getItem(STORAGE_KEY) ?? "")
-        : "",
+    openedSectionPaths: loadOpenedSectionPaths(),
   });
 
   $effect(() => {
-    sessionStorage.setItem(STORAGE_KEY, nav.openedSectionPath);
+    sessionStorage.setItem(STORAGE_KEY, JSON.stringify(nav.openedSectionPaths));
   });
 
   const processedLinks = [];

--- a/src/components/NavSection.svelte
+++ b/src/components/NavSection.svelte
@@ -119,19 +119,20 @@
         {:else if link.children && link.children.length}
 
           <button
-          aria-pressed={nav.openedSectionPath === link.path}
-          aria-expanded={nav.openedSectionPath === link.path}
-          class:open={nav.openedSectionPath === link.path}
+          aria-pressed={nav.openedSectionPaths.includes(link.path)}
+          aria-expanded={nav.openedSectionPaths.includes(link.path)}
+          class:open={nav.openedSectionPaths.includes(link.path)}
           onclick={() => {
-            nav.openedSectionPath =
-              nav.openedSectionPath === link.path ? '' : link.path;
+            nav.openedSectionPaths = nav.openedSectionPaths.includes(link.path)
+              ? nav.openedSectionPaths.filter((path) => path !== link.path)
+              : [...nav.openedSectionPaths, link.path];
           }}>
             {link.name}
           </button>
 
           <!-- The wrapper div must be a literal sibling of the button so the
                scoped `button + div` collapse rules aren't pruned as unused. -->
-          <div class:isOpenedChildren={nav.openedSectionPath.startsWith(link.path)}>
+          <div class:isOpenedChildren={nav.openedSectionPaths.includes(link.path)}>
             <NavSection
               links={link.children}
               hasLightBgColor={!hasLightBgColor}


### PR DESCRIPTION
Replace the single openedSectionPath string with an openedSectionPaths array so toggling one section no longer closes the others. Opened sections are persisted to sessionStorage as a JSON array under a new key, so each one still survives page navigations.


Claude-Session: https://claude.ai/code/session_011JDLg4mTZsLTgfQsrUaqWc