### PR TITLE
Animate nav section open/close to match chevron rotation

### DIFF
--- a/src/components/NavSection.svelte
+++ b/src/components/NavSection.svelte
@@ -29,6 +29,7 @@
 <style>
   div {
     width: 100%;
+    --menu-transition-duration: 0.3s;
   }
 
   a {
@@ -74,16 +75,24 @@
     background-position: center;
     float: right;
     transform: rotate(180deg);
-    transition: transform 0.3s;
+    transition: transform var(--menu-transition-duration);
   }
 
+  /* Animating to height: auto isn't possible, so the open/close is driven by
+     a single-row grid going from 0fr to 1fr, which can transition. */
   button + div {
-    height: 0;
+    display: grid;
+    grid-template-rows: 0fr;
     overflow: hidden;
+    transition: grid-template-rows var(--menu-transition-duration);
+  }
+
+  button + div > :global(*) {
+    min-height: 0;
   }
 
   button + div.isOpenedChildren {
-    height: auto;
+    grid-template-rows: 1fr;
     margin-left: -1.5rem;
   }
 


### PR DESCRIPTION
Section bodies previously snapped between height: 0 and height: auto while the chevron rotated over 0.3s. Drive the collapse with a single-row grid transitioning 0fr to 1fr, and share one --menu-transition-duration custom property between the chevron and the section so their timing can't drift apart.


Claude-Session: https://claude.ai/code/session_017qqocEBYThhMtDCfCZFBpM