### PR TITLE
Put two spaces between sentences in body text

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -47,6 +47,75 @@ function unwrapHtmlBlockParagraphs() {
   return (tree) => visit(tree);
 }
 
+// Rehype plugin: put two spaces between sentences in body text (headings are
+// left alone). HTML collapses runs of literal spaces, so the gap is rendered
+// as U+00A0 + a normal space, which browsers keep while still allowing a line
+// break at the boundary. A sentence boundary is end punctuation (plus any
+// closing quotes/brackets) followed by whitespace and a capitalized word;
+// periods after honorifics ("Mr.") or single initials ("James A. Michener",
+// "U.S.") don't count. Boundaries split across inline elements ("...end.</u>
+// Next") are found by carrying the preceding text and the pending whitespace
+// across text nodes, resetting at every non-inline element so formatting
+// whitespace between blocks is never touched.
+function doubleSpaceSentences() {
+  const SKIP = new Set(['h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'pre', 'code', 'script', 'style']);
+  const INLINE = new Set([
+    'a', 'abbr', 'b', 'cite', 'del', 'em', 'i', 'ins', 'mark', 'q', 'small',
+    'span', 'strong', 'sub', 'sup', 'time', 'u',
+  ]);
+  const END = `[.!?…][)\\]"'”’]*`;
+  const START = `[(\\["'“‘]*[A-Z]`;
+  const boundary = new RegExp(`(${END})(\\s+)(?=${START})`, 'g');
+  const endsSentence = new RegExp(`(${END})$`);
+  const startsSentence = new RegExp(`^${START}`);
+  const abbreviation =
+    /(?:\b(?:Mr|Mrs|Ms|Dr|Mt|St|Prof|Rev|Fr|Lt|Gen|Col|Capt|Sgt|No|vs)|(?:^|[^A-Za-z])[A-Z])$/;
+
+  // True when `punct` ends a sentence given the text leading up to it.
+  function isBoundary(punct, before) {
+    return punct[0] !== '.' || !abbreviation.test(before);
+  }
+
+  function processNode(node, ctx) {
+    if (node.type === 'text') {
+      // Boundary split across nodes: this node starts a sentence and the
+      // punctuation — and possibly the whitespace too — came earlier.
+      if (ctx.pending && startsSentence.test(node.value)) {
+        ctx.pending.value = ctx.pending.value.replace(/\s+$/, '\u00A0 ');
+      } else if (!ctx.pending && /^\s/.test(node.value)) {
+        const m = ctx.tail.match(endsSentence);
+        if (m && isBoundary(m[1], ctx.tail.slice(0, m.index)) &&
+            startsSentence.test(node.value.replace(/^\s+/, ''))) {
+          node.value = node.value.replace(/^\s+/, '\u00A0 ');
+        }
+      }
+      node.value = node.value.replace(boundary, (match, punct, ws, offset, str) =>
+        isBoundary(punct, str.slice(0, offset)) ? `${punct}\u00A0 ` : match
+      );
+      const m = node.value.match(new RegExp(`${END}\\s+$`));
+      ctx.pending = m && isBoundary(m[0], node.value.slice(0, m.index)) ? node : null;
+      ctx.tail = (ctx.tail + node.value).slice(-80);
+      return;
+    }
+    if (!node.children) {
+      // A childless node (<br>, an image, a comment, an MDX expression) may
+      // render anything, so don't look for a boundary across it.
+      Object.assign(ctx, { tail: '', pending: null });
+      return;
+    }
+    if (node.type === 'element' && SKIP.has(node.tagName)) {
+      Object.assign(ctx, { tail: '', pending: null });
+      return;
+    }
+    const inline = node.type === 'element' && INLINE.has(node.tagName);
+    const ctx2 = inline ? ctx : { tail: '', pending: null };
+    node.children.forEach((child) => processNode(child, ctx2));
+    if (!inline) Object.assign(ctx, { tail: '', pending: null });
+  }
+
+  return (tree) => processNode(tree, { tail: '', pending: null });
+}
+
 // Rehype plugin: wrap every U+02BB (ʻokina) in <span class="okina"> so that
 // the CSS can give it the correct font and layout, avoiding the overlap caused
 // by Gelasio's near-zero advance width for this character. (Carried over from
@@ -111,7 +180,7 @@ export default defineConfig({
     processor: unified({
       smartypants: { dashes: true },
       remarkPlugins: [unwrapHtmlBlockParagraphs],
-      rehypePlugins: [wrapOkina],
+      rehypePlugins: [doubleSpaceSentences, wrapOkina],
     }),
   },
   integrations: [mdx(), svelte()],

--- a/src/components/PersonalReligiousSymbolExplanation.astro
+++ b/src/components/PersonalReligiousSymbolExplanation.astro
@@ -8,8 +8,8 @@ const { highlight = 'var(--alt-bg-color-2)' } = Astro.props;
 
     <p>
         <span class="bold">Jack Shields Christensen</span> (1931-2018) first developed this symbol of belief in the mid-1970’s and
-        used it continually since. It derived from his studies of Taoism and the
-        writings of Lao Tzu. Using the translation from Chinese by Witter
+        used it continually since.&nbsp; It derived from his studies of Taoism and the
+        writings of Lao Tzu.&nbsp; Using the translation from Chinese by Witter
         Bynner, <span class="italic">The Way of Live According to Lao Tzu, an American Version</span>, 1944,
         the symbol is his personal visual representation of Verse 58,
         lines 12-15 (page 62 of the Capricorn Books Edition, 1962).


### PR DESCRIPTION
A rehype plugin in the shared markdown/MDX pipeline rewrites the single
space at each sentence boundary as U+00A0 plus a normal space, which
browsers render as a double space while still allowing a line break.
Headings, code, and inter-block whitespace are left alone, and periods
after honorifics and single initials (James A. Michener, U.S., Mt. Abu)
don't count as boundaries. Boundaries split across inline tags are
handled by carrying context between text nodes.

PersonalReligiousSymbolExplanation.astro renders outside the markdown
pipeline, so its two sentence boundaries get literal &nbsp; entities.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01KcaZSBPeMkKmz5MMhwQ4yG